### PR TITLE
Reduce Log Level

### DIFF
--- a/src/livereload.plugin.coffee
+++ b/src/livereload.plugin.coffee
@@ -70,7 +70,7 @@ module.exports = (BasePlugin) ->
 			{server,serverHttp} = opts
 
 			# Initialise Now
-			@socket = require('socket.io').listen(serverHttp or server).of('/docpad-live-reload')
+			@socket = require('socket.io').listen(serverHttp or server, {'log level': 1}).of('/docpad-live-reload')
 
 			# Chain
 			@


### PR DESCRIPTION
Socket.io defaults to the `debug` log level, needlessly cluttering the console output. `debug` is not really necessary for the purposes of this plugin.
Reduced to `warn`
