### PR TITLE
Fixes #3. Wait until page is loaded before injecting socket.io script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Automatically refreshes your [DocPad](https://docpad.org) built website whenever
   <%- @getBlock('scripts').toHTML() %>
   ```
 
+## Test
+
+See http://docpad.org/docs/plugin-write to setup a test environment, then run `cake test` to run tests.
 
 ## Configure
 

--- a/src/livereload.plugin.coffee
+++ b/src/livereload.plugin.coffee
@@ -64,6 +64,16 @@ module.exports = (BasePlugin) ->
 					s.parentNode.insertBefore(t,s);
 				};
 				"""
+			# We must make sure the page is ready before injecting our `script` tag,
+			# otherwise the `onload` event will not be registered.
+			injectCall = """		
+				var readyStateCheckInterval = setInterval(function() {
+				  if (document.readyState === "complete") {
+				    inject();
+				    clearInterval(readyStateCheckInterval);
+				  }
+				}, 10);
+				"""
 			scriptBlock =
 				if config.inject
 					"""
@@ -73,7 +83,7 @@ module.exports = (BasePlugin) ->
 							listen();
 						} else {
 							#{injectBlock}
-							inject();
+							#{injectCall}
 						}
 					})();
 					"""


### PR DESCRIPTION
Tested locally.

Add testing instructions to README.
